### PR TITLE
MQ_IMP_REWORK.md após inspeção

### DIFF
--- a/doc/manual_qualidade/IMP/MQ_IMP_REWORK.md
+++ b/doc/manual_qualidade/IMP/MQ_IMP_REWORK.md
@@ -13,6 +13,8 @@
 |---|---|---|---
 | 0.1 | 25/10/2018 | Alexandre Brito | Criação do processo |
 | 0.2 | 16/11/2018 | Flávio Fernandes|  Revisão de acordo com a inspeção |
+| 1.0 | 18/11/2018 | Vítor Ribeiro    | Revisão e aprovação de acordo com a revisão da inspeção |
+
 
 #### DESCRIÇÃO DO PROCESSO
 

--- a/doc/manual_qualidade/IMP/MQ_IMP_REWORK.md
+++ b/doc/manual_qualidade/IMP/MQ_IMP_REWORK.md
@@ -1,0 +1,60 @@
+## Processo de Correção de Código
+
+
+**DOC ID:** MQ_IMP_REWORK
+
+| UNIDADE | COORDENADOR |
+|---------|-------------|
+|    IMP   |João Montenegro|
+
+#### TABELA DE VERSÕES
+
+| Versão | Data | Autor(es) | Descrição
+|---|---|---|---
+| 0.1 | 25/10/2018 | Alexandre Brito | Criação do processo |
+| 0.2 | 16/11/2018 | Flávio Fernandes|  Revisão de acordo com a inspeção |
+
+#### DESCRIÇÃO DO PROCESSO
+
+Este processo descreve o funcionamento de revisão de código com problemas detetados pela equipa de testes
+
+#### RESPONSÁVEIS
+
+Todos os membros da unidade
+
+#### INPUTS
+
+- Erros detetados pela equipa de testes
+
+#### CRITÉRIO DE ENTRADA/ATIVAÇÃO
+
+- Tickets no trello feitos pela equipa de testes sobre os problemas detetados
+
+#### DESCRIÇÃO DAS TAREFAS
+
+- Atribuição da tarefa, tanto por iniciativa própria como pelo coordenador.
+- Análise do problema.
+- Deteção e posterior correção dos erros.
+
+#### CICLO DE VIDA DOS ARTEFACTOS
+
+1. Correção dos erros;
+2. Aprovação do código pelo coordenador;
+3. Devolução do novo código a testes para revisão;
+
+#### OUTPUTS
+
+ - Código fonte corrigido (+ atualização da lista de componentes para rever)
+
+#### CRITÉRIO DE SAÍDA
+
+- Upload de ficheiros com código-fonte e validação pelos responsáveis
+
+#### MÉTRICAS DE AVALIAÇÃO
+
+- Tempo de horas necessárias para a resolução do problema.
+- Número de erros resolvidos
+
+#### APROVAÇÃO E VALIDAÇÃO
+
+- Aprovação do código pelo coordenador. Validação feita pela equipa de testes.


### PR DESCRIPTION
Por sugestão do docente, o nome deste processo foi alterado. Antes tinha a denominação de MQ_IMP_REVIEW, após a sugestão do mesmo, fica MQ_IMP_REWORK. O MQ_IMP_REVIEW pode ser eliminado.